### PR TITLE
support faraday 2.x

### DIFF
--- a/lib/base.rb
+++ b/lib/base.rb
@@ -1,4 +1,6 @@
-require 'faraday_middleware'
+if Gem::Version.new(Faraday::VERSION) < Gem::Version.new('2.0')
+  require 'faraday_middleware'
+end
 
 module SendGridWebApi
   class Base

--- a/sendgrid_webapi.gemspec
+++ b/sendgrid_webapi.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "faraday",          "~> 1.0"
-  s.add_dependency "faraday_middleware",  "~> 1.0"
+  s.add_dependency "faraday"
   s.add_dependency "json", "~> 2.0"
 
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "webmock", "~> 3.12"
   s.add_development_dependency "vcr", "~> 6.0"

--- a/spec/cassettes/client/_modules/_block/should_get_block_emails.yml
+++ b/spec/cassettes/client/_modules/_block/should_get_block_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:37:37 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_block/should_get_totals_blocks.yml
+++ b/spec/cassettes/client/_modules/_block/should_get_totals_blocks.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:37:40 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_block/should_try_delete_not_existing_block_email.yml
+++ b/spec/cassettes/client/_modules/_block/should_try_delete_not_existing_block_email.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:37:38 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_bounce/should_get_bounce_emails.yml
+++ b/spec/cassettes/client/_modules/_bounce/should_get_bounce_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:31 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_bounce/should_get_bounce_emails_using_params.yml
+++ b/spec/cassettes/client/_modules/_bounce/should_get_bounce_emails_using_params.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:31 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_bounce/should_get_totals_bounces.yml
+++ b/spec/cassettes/client/_modules/_bounce/should_get_totals_bounces.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 12:25:48 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_bounce/should_try_delete_not_existing_bounce_email.yml
+++ b/spec/cassettes/client/_modules/_bounce/should_try_delete_not_existing_bounce_email.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:32 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_invalid_email/should_get_invalid_emails.yml
+++ b/spec/cassettes/client/_modules/_invalid_email/should_get_invalid_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:56 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_invalid_email/should_get_invalid_emails_using_params.yml
+++ b/spec/cassettes/client/_modules/_invalid_email/should_get_invalid_emails_using_params.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:56 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_invalid_email/should_try_delete_not_existing_invalid_emails.yml
+++ b/spec/cassettes/client/_modules/_invalid_email/should_try_delete_not_existing_invalid_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:39:58 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_spam/should_get_spam_emails.yml
+++ b/spec/cassettes/client/_modules/_spam/should_get_spam_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:48:27 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_spam/should_try_delete_not_existing_spam_emails.yml
+++ b/spec/cassettes/client/_modules/_spam/should_try_delete_not_existing_spam_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:48:28 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_unsubscribe/should_add_unsubscribe_emails.yml
+++ b/spec/cassettes/client/_modules/_unsubscribe/should_add_unsubscribe_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:49:15 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_unsubscribe/should_delete_unsubscribe_email.yml
+++ b/spec/cassettes/client/_modules/_unsubscribe/should_delete_unsubscribe_email.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:49:18 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_unsubscribe/should_get_unsubscribe_emails.yml
+++ b/spec/cassettes/client/_modules/_unsubscribe/should_get_unsubscribe_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:49:16 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/cassettes/client/_modules/_unsubscribe/should_try_delete_not_existing_unsubscribe_emails.yml
+++ b/spec/cassettes/client/_modules/_unsubscribe/should_try_delete_not_existing_unsubscribe_emails.yml
@@ -23,7 +23,7 @@ http_interactions:
       Date:
       - Fri, 17 Jan 2014 01:49:19 GMT
       Content-Type:
-      - text/html
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:


### PR DESCRIPTION
Description
-----------

The current gemspec prevents this project from being used in projects that are using modern farday (2.x). This PR allows sendgrid_webapi to operate in either environment. 


Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
